### PR TITLE
added numpy version check for fits write method dependency

### DIFF
--- a/util/FITS.py
+++ b/util/FITS.py
@@ -21,6 +21,7 @@ import numpy
 import os.path,os
 import fcntl
 import traceback
+import distutils.version
 error = 'FITS error'
 #
 # Read a FITS image file
@@ -235,8 +236,10 @@ def Write(data, filename, extraHeader = None,writeMode='w',doByteSwap=1,preserve
     file.write(header)
     if numpy.little_endian and doByteSwap:
         data.byteswap(True)
-    #data.tofile(file)
-    file.write(data.tobytes())
+    if distutils.version.LooseVersion(numpy.version.version) < distutils.version.LooseVersion('1.9.0'):
+        data.tofile(file)
+    else:
+        file.write(data.tobytes()) 
     numBlock = (data.itemsize*data.size + 2880 - 1) // 2880
     padding = ' ' * (numBlock*2880 - data.itemsize*data.size)
     file.write(padding)


### PR DESCRIPTION
numpy.ndarray.tobytes() works for bumpy version >=1.9.0, added a version check to avoid failure for earlier bumpy versions (did not work on Ubuntu 14.04 with Python 2.7.6 and numpy 1.8.2) .
See also https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.tobytes.html
