### PR TITLE
Cast float to int to fix Numpy error

### DIFF
--- a/gui/bin/daspbuilder.py
+++ b/gui/bin/daspbuilder.py
@@ -1912,7 +1912,7 @@ n=fftsize*(nFieldX+1.)/2
 #data=interpolation.zoom(data,wfs_nsubx*(n+2*b)/data.shape[0])
 #For identical image per subap, use this one:
 data=interpolation.zoom(data,(n+2*b)/data.shape[0])*100
-widefieldImage=numpy.zeros((wfs_nsubx,wfs_nsubx,n+2*b,n+2*b),numpy.float32)
+widefieldImage=numpy.zeros((wfs_nsubx,wfs_nsubx,int(n+2*b),int(n+2*b)),numpy.float32)
 for i in range(wfs_nsubx):
     for j in range(wfs_nsubx):
         widefieldImage[i,j]=data # use this for same image per subap.


### PR DESCRIPTION
When you run the `daspbuilder.py` to build a Solar simulation, the `params.py` file generated has a cast issue.  
The `loadPyConfig` method from the [readConfig.py#205](https://github.com/agb32/dasp/blob/master/base/readConfig.py#L205) class throw the error :
> TypeError : 'float'  object cannot be interpreted as an index  

![UbuntuDaspInstalld1](https://user-images.githubusercontent.com/51918753/117827645-75108e80-b271-11eb-9641-a24015fac0f6.jpg)

This PR correct this error